### PR TITLE
First word only

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,10 +5,10 @@ Change log
 1.7.1 (unreleased)
 ==================
 
-- Add an option in the Glossary control panel to highlight on the first word
+- Add an option in the Glossary control panel to highlight only the first word
   found on a page. This is useful in for example scientific documents where the
   same terms are used a lot, which can cause excessive highlighting. Disabled
-  by default to keep default behaviour (highlight all terms found)
+  by default to keep default behaviour (highlight all terms found).
   [fredvd]
 
 1.7 (2014-01-10)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,11 +5,15 @@ Change log
 1.7.1 (unreleased)
 ==================
 
+- Add ``Products.PloneTestCase`` to the ``test`` extra requirements.
+  [maurits]
+
 - Add an option in the Glossary control panel to highlight only the first word
   found on a page. This is useful in for example scientific documents where the
   same terms are used a lot, which can cause excessive highlighting. Disabled
   by default to keep default behaviour (highlight all terms found).
   [fredvd]
+
 
 1.7 (2014-01-10)
 ================
@@ -34,6 +38,7 @@ Change log
   flag file for our ``ploneglossary-reg`` import step.
   Fixes http://plone.org/products/ploneglossary/issues/8
   [maurits]
+
 
 1.6 (2013-08-26)
 ================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,8 +5,11 @@ Change log
 1.7.1 (unreleased)
 ==================
 
-- Nothing changed yet.
-
+- Add an option in the Glossary control panel to highlight on the first word
+  found on a page. This is useful in for example scientific documents where the
+  same terms are used a lot, which can cause excessive highlighting. Disabled
+  by default to keep default behaviour (highlight all terms found)
+  [fredvd]
 
 1.7 (2014-01-10)
 ================

--- a/Products/PloneGlossary/PloneGlossaryTool.py
+++ b/Products/PloneGlossary/PloneGlossaryTool.py
@@ -79,6 +79,9 @@ class PloneGlossaryTool(PropertyManager, UniqueObject, SimpleItem):
         {'id': 'highlight_content',
          'type': 'boolean',
          'mode': 'w'},
+        {'id': 'first_word_only',
+         'type': 'boolean',
+         'mode': 'w'},         
         {'id': 'use_general_glossaries',
          'type': 'boolean',
          'mode': 'w'},
@@ -108,6 +111,7 @@ class PloneGlossaryTool(PropertyManager, UniqueObject, SimpleItem):
         )
 
     highlight_content = True
+    first_word_only = False
     use_general_glossaries = True
     general_glossary_uids = []
     allowed_portal_types = ['PloneGlossaryDefinition']
@@ -178,6 +182,10 @@ class PloneGlossaryTool(PropertyManager, UniqueObject, SimpleItem):
             return optional.do_highlight(default=self.highlight_content)
 
         return self.highlight_content
+
+    security.declarePublic('firstWordOnly')
+    def firstWordOnly(self):
+        return self.first_word_only
 
     security.declarePublic('getUsedGlossaryUIDs')
     def getUsedGlossaryUIDs(self, obj):

--- a/Products/PloneGlossary/i18n/glossary-nl.po
+++ b/Products/PloneGlossary/i18n/glossary-nl.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PloneGlossary 1.0\n"
-"POT-Creation-Date: 2011-11-21 14:42+0000\n"
+"POT-Creation-Date: 2014-10-15 08:38+0000\n"
 "PO-Revision-Date: 2011-11-21 15:45+0100\n"
 "Last-Translator: Maurits van Rees <m.van.rees@zestsoftware.nl>\n"
 "Language-Team: Plone Nederlands <plone-nl@lists.plone.org>\n"
@@ -18,7 +18,7 @@ msgstr ""
 "Domain: ploneglossary\n"
 "X-Is-Fallback-For: nl-be nl-nl\n"
 
-#: ./browser/portlet.py:86
+#: ./browser/portlet.py:89
 msgid "Add Glossary Portlet"
 msgstr "Voeg Begrippenlijst portlet toe"
 
@@ -56,7 +56,7 @@ msgstr "Begrip"
 msgid "Search"
 msgstr "Zoeken"
 
-#: ./browser/portlet.py:87
+#: ./browser/portlet.py:90
 msgid "This portlet shows the definitions of terms of the current page."
 msgstr "Deze portlet toont de definities van termen van de huidige pagina."
 
@@ -83,7 +83,7 @@ msgstr "Gerelateerde termen"
 #. Select glossaries used to check related terms of content.
 #. No selection results in the same thing of selecting all glossaries.
 #. Default: "Select portal types allowed to be highlighted, if highlight feature is enabled. No selection results in the same thing of selecting all portal types."
-#: ./skins/PloneGlossary/ploneglossary_management_form.cpt:145
+#: ./skins/PloneGlossary/ploneglossary_management_form.cpt:168
 msgid "help_allowed_portal_types"
 msgstr "Selecteer de contenttypes, waarbij de trefwoorden actief moeten zijn. Geen selectie resulteert in weergave van trefwoorden bij alle types."
 
@@ -91,7 +91,7 @@ msgstr "Selecteer de contenttypes, waarbij de trefwoorden actief moeten zijn. Ge
 #. Enter ellipsis. It is used in popup when definition of term is too long.
 #. </div>
 #. Default: "Enter ellipsis. It is used in popup when definition of term is too long."
-#: ./skins/PloneGlossary/ploneglossary_management_form.cpt:99
+#: ./skins/PloneGlossary/ploneglossary_management_form.cpt:122
 msgid "help_description_ellipsis"
 msgstr "Voer de doorlooppuntjes in. Deze wordt gebruikt als de definitie van de term te lang is."
 
@@ -99,12 +99,17 @@ msgstr "Voer de doorlooppuntjes in. Deze wordt gebruikt als de definitie van de 
 #. Enter maximum description length of term.
 #. </div>
 #. Default: "Enter maximum description length of term."
-#: ./skins/PloneGlossary/ploneglossary_management_form.cpt:77
+#: ./skins/PloneGlossary/ploneglossary_management_form.cpt:100
 msgid "help_description_length"
 msgstr "Maximale lengte van de beschrijving van de term."
 
+#. Default: "If a term is on the page multiple times, only highlight the first instance found."
+#: ./skins/PloneGlossary/ploneglossary_management_form.cpt:84
+msgid "help_first_word_only"
+msgstr "Als een woord meerdere keren op de pagina voorkomt, markeerd alleen het eerste woord in de tekst."
+
 #. Default: "Select glossaries used to check related terms of content. By default all glossaries will be used."
-#: ./skins/PloneGlossary/ploneglossary_management_form.cpt:199
+#: ./skins/PloneGlossary/ploneglossary_management_form.cpt:222
 msgid "help_general_glossary_uids"
 msgstr "De begrippenlijsten waarin de begrippen gevonden mogen worden. Standaard worden alle termen opgezocht."
 
@@ -132,12 +137,12 @@ msgid "help_highlight_content"
 msgstr "Vink aan om de geralateerde termen te markeren. Geselecteerde begrippen worden gemarkeerd."
 
 #. Default: "Enter one tag name per line. Tags specified below will not be highlighted. A tag may be in the form 'tag' to match any tag, 'tag#select' to match tag with id 'select', or 'tag.someclass' to match all tags with CSS class 'someclass'."
-#: ./skins/PloneGlossary/ploneglossary_management_form.cpt:121
+#: ./skins/PloneGlossary/ploneglossary_management_form.cpt:144
 msgid "help_not_highlighted_tags"
 msgstr "Vul een html-tag per regel in. Html-tags hieronder benoemd worden niet gemarkeerd. Een tag mag de vorm 'tag' hebben om elke van die tags te matchen, 'tag#select' om tags met id 'select' te matchen of 'tag.eenclass' om al die tags met CSS class 'eenclass' te matchen."
 
 #. Default: "When checked, all glossaries will be used to highlight terms globally for all of the site's content.<br /> By unchecking this option, only the first glossary found while traversing upwards from the current location will be used."
-#: ./skins/PloneGlossary/ploneglossary_management_form.cpt:182
+#: ./skins/PloneGlossary/ploneglossary_management_form.cpt:205
 msgid "help_use_general_glossaries"
 msgstr "Aangevinkt, worden alle begrippenlijsten gebruikt om de begrippen te markeren.<br />Niet aangevinkt, wordt alleen de eerste bovenliggende begrippenlijst gebruikt."
 
@@ -145,7 +150,7 @@ msgstr "Aangevinkt, worden alle begrippenlijsten gebruikt om de begrippen te mar
 #. Allowed portal types
 #. </label>
 #. Default: "Allowed portal types"
-#: ./skins/PloneGlossary/ploneglossary_management_form.cpt:140
+#: ./skins/PloneGlossary/ploneglossary_management_form.cpt:163
 msgid "label_allowed_portal_types"
 msgstr "Geactiveerde contenttypes"
 
@@ -153,7 +158,7 @@ msgstr "Geactiveerde contenttypes"
 #. Description ellipsis
 #. </label>
 #. Default: "Description ellipsis"
-#: ./skins/PloneGlossary/ploneglossary_management_form.cpt:94
+#: ./skins/PloneGlossary/ploneglossary_management_form.cpt:117
 msgid "label_description_ellipsis"
 msgstr "Gerelateerde termen"
 
@@ -161,15 +166,20 @@ msgstr "Gerelateerde termen"
 #. Description length
 #. </label>
 #. Default: "Description length"
-#: ./skins/PloneGlossary/ploneglossary_management_form.cpt:72
+#: ./skins/PloneGlossary/ploneglossary_management_form.cpt:95
 msgid "label_description_length"
 msgstr "Lengte van de omschrijving"
+
+#. Default: "Only highlight the first word ?"
+#: ./skins/PloneGlossary/ploneglossary_management_form.cpt:79
+msgid "label_first_word_only"
+msgstr "Markeer alleen het eerst gevonden woord"
 
 #. <label for="general_glossary_uids" i18n:translate="label_general_glossary_uids">
 #. General glossaries
 #. </label>
 #. Default: "General glossaries"
-#: ./skins/PloneGlossary/ploneglossary_management_form.cpt:194
+#: ./skins/PloneGlossary/ploneglossary_management_form.cpt:217
 msgid "label_general_glossary_uids"
 msgstr "Standaard begrippenlijsten"
 
@@ -201,7 +211,7 @@ msgstr "Markeer content?"
 #. Not highlighted tags
 #. </label>
 #. Default: "Not highlighted tags"
-#: ./skins/PloneGlossary/ploneglossary_management_form.cpt:116
+#: ./skins/PloneGlossary/ploneglossary_management_form.cpt:139
 msgid "label_not_highlighted_tags"
 msgstr "Niet gemarkeerde begrippen."
 
@@ -214,7 +224,7 @@ msgid "label_text_search"
 msgstr "Zoek"
 
 #. Default: "Use glossaries globally for all content?"
-#: ./skins/PloneGlossary/ploneglossary_management_form.cpt:178
+#: ./skins/PloneGlossary/ploneglossary_management_form.cpt:201
 msgid "label_use_general_glossaries"
 msgstr "Begrippen gebruiken voor alle content?"
 

--- a/Products/PloneGlossary/i18n/glossary-nl.po
+++ b/Products/PloneGlossary/i18n/glossary-nl.po
@@ -106,7 +106,7 @@ msgstr "Maximale lengte van de beschrijving van de term."
 #. Default: "If a term is on the page multiple times, only highlight the first instance found."
 #: ./skins/PloneGlossary/ploneglossary_management_form.cpt:84
 msgid "help_first_word_only"
-msgstr "Als een woord meerdere keren op de pagina voorkomt, markeerd alleen het eerste woord in de tekst."
+msgstr "Als een woord meerdere keren op de pagina voorkomt, markeer alleen het eerste woord in de tekst."
 
 #. Default: "Select glossaries used to check related terms of content. By default all glossaries will be used."
 #: ./skins/PloneGlossary/ploneglossary_management_form.cpt:222

--- a/Products/PloneGlossary/i18n/glossary.pot
+++ b/Products/PloneGlossary/i18n/glossary.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Products.PloneGlossary 1.0\n"
-"POT-Creation-Date: 2011-11-21 14:42+0000\n"
+"POT-Creation-Date: 2014-10-15 08:38+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,7 +17,7 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: ploneglossary\n"
 
-#: ./browser/portlet.py:86
+#: ./browser/portlet.py:89
 msgid "Add Glossary Portlet"
 msgstr ""
 
@@ -55,7 +55,7 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
-#: ./browser/portlet.py:87
+#: ./browser/portlet.py:90
 msgid "This portlet shows the definitions of terms of the current page."
 msgstr ""
 
@@ -70,22 +70,27 @@ msgid "heading_related_terms"
 msgstr ""
 
 #. Default: "Select portal types allowed to be highlighted, if highlight feature is enabled. No selection results in the same thing of selecting all portal types."
-#: ./skins/PloneGlossary/ploneglossary_management_form.cpt:145
+#: ./skins/PloneGlossary/ploneglossary_management_form.cpt:168
 msgid "help_allowed_portal_types"
 msgstr ""
 
 #. Default: "Enter ellipsis. It is used in popup when definition of term is too long."
-#: ./skins/PloneGlossary/ploneglossary_management_form.cpt:99
+#: ./skins/PloneGlossary/ploneglossary_management_form.cpt:122
 msgid "help_description_ellipsis"
 msgstr ""
 
 #. Default: "Enter maximum description length of term."
-#: ./skins/PloneGlossary/ploneglossary_management_form.cpt:77
+#: ./skins/PloneGlossary/ploneglossary_management_form.cpt:100
 msgid "help_description_length"
 msgstr ""
 
+#. Default: "If a term is on the page multiple times, only highlight the first instance found."
+#: ./skins/PloneGlossary/ploneglossary_management_form.cpt:84
+msgid "help_first_word_only"
+msgstr ""
+
 #. Default: "Select glossaries used to check related terms of content. By default all glossaries will be used."
-#: ./skins/PloneGlossary/ploneglossary_management_form.cpt:199
+#: ./skins/PloneGlossary/ploneglossary_management_form.cpt:222
 msgid "help_general_glossary_uids"
 msgstr ""
 
@@ -110,32 +115,37 @@ msgid "help_highlight_content"
 msgstr ""
 
 #. Default: "Enter one tag name per line. Tags specified below will not be highlighted. A tag may be in the form 'tag' to match any tag, 'tag#select' to match tag with id 'select', or 'tag.someclass' to match all tags with CSS class 'someclass'."
-#: ./skins/PloneGlossary/ploneglossary_management_form.cpt:121
+#: ./skins/PloneGlossary/ploneglossary_management_form.cpt:144
 msgid "help_not_highlighted_tags"
 msgstr ""
 
 #. Default: "When checked, all glossaries will be used to highlight terms globally for all of the site's content.<br /> By unchecking this option, only the first glossary found while traversing upwards from the current location will be used."
-#: ./skins/PloneGlossary/ploneglossary_management_form.cpt:182
+#: ./skins/PloneGlossary/ploneglossary_management_form.cpt:205
 msgid "help_use_general_glossaries"
 msgstr ""
 
 #. Default: "Allowed portal types"
-#: ./skins/PloneGlossary/ploneglossary_management_form.cpt:140
+#: ./skins/PloneGlossary/ploneglossary_management_form.cpt:163
 msgid "label_allowed_portal_types"
 msgstr ""
 
 #. Default: "Description ellipsis"
-#: ./skins/PloneGlossary/ploneglossary_management_form.cpt:94
+#: ./skins/PloneGlossary/ploneglossary_management_form.cpt:117
 msgid "label_description_ellipsis"
 msgstr ""
 
 #. Default: "Description length"
-#: ./skins/PloneGlossary/ploneglossary_management_form.cpt:72
+#: ./skins/PloneGlossary/ploneglossary_management_form.cpt:95
 msgid "label_description_length"
 msgstr ""
 
+#. Default: "Only highlight the first word ?"
+#: ./skins/PloneGlossary/ploneglossary_management_form.cpt:79
+msgid "label_first_word_only"
+msgstr ""
+
 #. Default: "General glossaries"
-#: ./skins/PloneGlossary/ploneglossary_management_form.cpt:194
+#: ./skins/PloneGlossary/ploneglossary_management_form.cpt:217
 msgid "label_general_glossary_uids"
 msgstr ""
 
@@ -161,7 +171,7 @@ msgid "label_highlight_content"
 msgstr ""
 
 #. Default: "Not highlighted tags"
-#: ./skins/PloneGlossary/ploneglossary_management_form.cpt:116
+#: ./skins/PloneGlossary/ploneglossary_management_form.cpt:139
 msgid "label_not_highlighted_tags"
 msgstr ""
 
@@ -171,7 +181,7 @@ msgid "label_text_search"
 msgstr ""
 
 #. Default: "Use glossaries globally for all content?"
-#: ./skins/PloneGlossary/ploneglossary_management_form.cpt:178
+#: ./skins/PloneGlossary/ploneglossary_management_form.cpt:201
 msgid "label_use_general_glossaries"
 msgstr ""
 

--- a/Products/PloneGlossary/profiles/default/glossary.xml
+++ b/Products/PloneGlossary/profiles/default/glossary.xml
@@ -2,6 +2,7 @@
 <object name="portal_glossary" meta_type="PloneGlossaryTool">
  <property name="title">PloneGlossaryTool</property>
  <property name="highlight_content" type="boolean">True</property>
+ <property name="first_word_only" type="boolean">False</property>
  <property name="use_general_glossaries" type="boolean">False</property>
  <property name="general_glossary_uids" select_variable="getGlossaryUIDs"
     type="multiple selection"/>

--- a/Products/PloneGlossary/skins/PloneGlossary/ploneglossary.js.dtml
+++ b/Products/PloneGlossary/skins/PloneGlossary/ploneglossary.js.dtml
@@ -122,10 +122,18 @@ function highlight_related_glossary_term_in_text(node, word, definition_index) {
     var content_value = node.nodeValue;
     var lcontent_value = content_value.toLowerCase();
     var word_bounds = new Array();
-    // Write 3 regexps to replace one because it doesn't work on IE: '\\b' + lword + '\\b'
+    /* Write multiple regexps to replace one because it doesn't work
+     * on IE: '\\b' + lword + '\\b'
+
+     * Please keep this in the order that finds the first match first:
+     * in a sentence with 'word word' the first word should be found
+     * first, so its regexp needs to be listed before the regexp that
+     * only finds words mid-sentence. */
     word_bounds.push('^' + lword + '$'); // word is the sentence
+    word_bounds.push('^' + lword + '\\W'); // word is beginning a sentence
+    // Note: for the next two, the found index includes the blank
+    // space, so we need to increase the index when we loop over it.
     word_bounds.push('\\W' + lword + '\\W'); // word is included in a sentence
-    word_bounds.push('^' + lword + '\\W'); // word is begining a sentence
     word_bounds.push('\\W' + lword + '$'); // word is finishing a sentence
     var index = -1;
 
@@ -133,8 +141,9 @@ function highlight_related_glossary_term_in_text(node, word, definition_index) {
     for (var i=0; i<word_bounds.length;i++) {
         index = lcontent_value.search(word_bounds[i]);
         if (index != -1) {
-            if (i == 1 || i == 3) {
-                // Position of search is one character before the real char of the word
+            if (i == 2 || i == 3) {
+                // Position of search is one character before the real
+                // start of the word.  See the note above.
                 index += 1;
             }
             break;

--- a/Products/PloneGlossary/skins/PloneGlossary/ploneglossary.js.dtml
+++ b/Products/PloneGlossary/skins/PloneGlossary/ploneglossary.js.dtml
@@ -141,6 +141,15 @@ function highlight_related_glossary_term_in_text(node, word, definition_index) {
     // Word is found
     var last_index = index + word.length;
 
+    // Only highlight the first instance found ?
+    if (typeof dictionary_found != "undefined") {
+        if (dictionary_found[word] === '1') {
+            return;
+        } else {
+            dictionary_found[word] = '1';
+        }
+    }
+
     if (index != -1) {
         // Create Highlighted term
         var hiword = document.createElement("span");

--- a/Products/PloneGlossary/skins/PloneGlossary/ploneglossary.js.dtml
+++ b/Products/PloneGlossary/skins/PloneGlossary/ploneglossary.js.dtml
@@ -143,10 +143,10 @@ function highlight_related_glossary_term_in_text(node, word, definition_index) {
 
     // Only highlight the first instance found ?
     if (typeof dictionary_found != "undefined") {
-        if (dictionary_found[word] === '1') {
+        if (dictionary_found[lword] === '1') {
             return;
         } else {
-            dictionary_found[word] = '1';
+            dictionary_found[lword] = '1';
         }
     }
 

--- a/Products/PloneGlossary/skins/PloneGlossary/ploneglossary.js.dtml
+++ b/Products/PloneGlossary/skins/PloneGlossary/ploneglossary.js.dtml
@@ -113,6 +113,12 @@ function highlight_related_glossary_term_in_text(node, word, definition_index) {
     }
 
     var lword = word.toLowerCase();
+    // Only highlight the first instance found ?
+    if (typeof dictionary_found != "undefined") {
+        if (dictionary_found[lword] === '1') {
+            return;
+        };
+    };
     var content_value = node.nodeValue;
     var lcontent_value = content_value.toLowerCase();
     var word_bounds = new Array();
@@ -143,12 +149,8 @@ function highlight_related_glossary_term_in_text(node, word, definition_index) {
 
     // Only highlight the first instance found ?
     if (typeof dictionary_found != "undefined") {
-        if (dictionary_found[lword] === '1') {
-            return;
-        } else {
-            dictionary_found[lword] = '1';
-        }
-    }
+        dictionary_found[lword] = '1';
+    };
 
     if (index != -1) {
         // Create Highlighted term

--- a/Products/PloneGlossary/skins/PloneGlossary/ploneglossary_definitions.js.pt
+++ b/Products/PloneGlossary/skins/PloneGlossary/ploneglossary_definitions.js.pt
@@ -4,11 +4,15 @@
                   highlight python:test(gtool.highlightContent(here), 1, 0);
                   definitions python:gtool.getDefinitionsForUI(here, request);
                   escape python:gtool.escape;
-                  truncateDescription python:gtool.truncateDescription"
+                  truncateDescription python:gtool.truncateDescription;
+                  firstWordOnly python:gtool.firstWordOnly"
           condition="python: len(definitions) > 0">
 
+<tal:firstword tal:condition="firstWordOnly">
+var dictionary_found = new Array();
+</tal:firstword>
 <tal:loop repeat="def definitions">
-var terms = new Array();
+var terms = new Array(); 
 <tal:term_loop repeat="term def/terms">
 terms.push("<tal:content replace="term" />");
 </tal:term_loop>

--- a/Products/PloneGlossary/skins/PloneGlossary/ploneglossary_management_edit.cpy
+++ b/Products/PloneGlossary/skins/PloneGlossary/ploneglossary_management_edit.cpy
@@ -18,6 +18,7 @@ putils = getToolByName(context, 'plone_utils')
 
 properties = {}
 properties['highlight_content'] = request.get('highlight_content', 0)
+properties['first_word_only'] = request.get('first_word_only', 0)
 properties['use_general_glossaries'] = request.get('use_general_glossaries', 0)
 properties['allowed_portal_types'] = request.get('allowed_portal_types', [])
 properties['general_glossary_uids'] = request.get('general_glossary_uids', [])

--- a/Products/PloneGlossary/skins/PloneGlossary/ploneglossary_management_form.cpt
+++ b/Products/PloneGlossary/skins/PloneGlossary/ploneglossary_management_form.cpt
@@ -67,6 +67,29 @@
             </div>
 
             <div class="field"
+                 tal:define="first_word_only request/first_word_only | gtool/first_word_only;">
+
+              <input type="checkbox"
+                     class="noborder"
+                     id="first_word_only"
+                     name="first_word_only"
+                     tabindex=""
+                     tal:attributes="checked python:test(first_word_only, 'checked', None);
+                                     tabindex tabindex/next|nothing;" />
+              <label for="first_word_only"
+                     i18n:translate="label_first_word_only">
+                Only highlight the first word ? 
+              </label>
+
+              <div class="formHelp"
+                   i18n:translate="help_first_word_only">
+                If a term is on the page multiple times, only highlight the first instance found.
+              </div>
+
+
+
+            </div>
+            <div class="field"
                  tal:define="description_length python:request.get('description_length', int(gtool.description_length));">
 
               <label for="description_length"

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -4,6 +4,7 @@ extends =
 
 extensions += buildout.dumppickedversions
 package-name = Products.PloneGlossary
+package-extras = [test]
 socket-timeout = 3
 
 # To test with dexterity content types:

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,9 @@ setup(
         'setuptools',
         'wicked',
         ],
+    extras_require={
+        'test': ['Products.PloneTestCase'],
+        },
     entry_points="""
     # -*- Entry points: -*-
     """,


### PR DESCRIPTION
Add an option in the Glossary control panel to highlight only the first word found on a page.
